### PR TITLE
Fix crypto lib call for node versions < v17.4.0

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ const { words } = require("./src/words");
 const { binaryToByte, bytesToBinary } = require("./src/utils");
 
 function randomBytes(byteLength) {
-  return crypto.getRandomValues(new Uint8Array(byteLength));
+  return crypto.webcrypto.getRandomValues(new Uint8Array(byteLength));
 }
 
 async function deriveChecksumBits(entropy) {


### PR DESCRIPTION
`crypto.getRandomValues` used in https://github.com/boxyhq/error-code-mnemonic/blob/d8a935f1106a26f655b990b90a3f0402d468f530/js/index.js#L7 was added in nodev17 as an alias for `crypto.webcrypto.getRandomValues`. And it won't work in node < v17.4.0.

Switching the call to `crypto.webcrypto.getRandomValues` would fix this for older versions of node and also make the code web-compatible.

